### PR TITLE
Correct travis shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 check_k8s: Kubernetes plugin for Nagios
 ===
 
-![Travis (.org)](https://img.shields.io/travis/itrs-group/check_k8s) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/ITRS-Group/check_k8s.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ITRS-Group/check_k8s/context:python) ![GitHub](https://img.shields.io/github/license/itrs-group/check_k8s)
+![Travis (.com)](https://img.shields.io/travis/com/itrs-group/check_k8s) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/ITRS-Group/check_k8s.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ITRS-Group/check_k8s/context:python) ![GitHub](https://img.shields.io/github/license/itrs-group/check_k8s)
 
 Nagios plugin for monitoring Kubernetes Clusters, built using the Python standard library.
 


### PR DESCRIPTION
We are using travis-ci.com instead of travis-ci.org which seem to
require a slightly different shield URL. This commit should fix that.