### PR TITLE
Print errors to stdout

### DIFF
--- a/check_k8s.py
+++ b/check_k8s.py
@@ -42,16 +42,16 @@ def main():
         output = Output(
             NaemonState.UNKNOWN,
             "{0}: {1}".format(e.code, body.get("message")),
-            sys.stderr
+            sys.stdout
         )
     except URLError as e:
-        output = Output(NaemonState.UNKNOWN, e.reason, sys.stderr)
+        output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
     except Exception as e:
         if parsed.debug:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             traceback.print_tb(exc_traceback, file=sys.stdout)
 
-        output = Output(NaemonState.UNKNOWN, e, sys.stderr)
+        output = Output(NaemonState.UNKNOWN, e, sys.stdout)
 
     msg = NAGIOS_MSG.format(state=output.state.name, message=output.message)
     output.channel.write(msg)

--- a/k8s/result.py
+++ b/k8s/result.py
@@ -44,7 +44,7 @@ class Result:
 
         return ["{}={}".format(k, v) for k, v in self._perfdata.items()]
 
-    def _get_output(self, state, summary, channel=sys.stderr):
+    def _get_output(self, state, summary, channel=sys.stdout):
         """Produces an Output object for accessing Naemon state, messages and channel
 
         :param state: NaemonState object


### PR DESCRIPTION
Naemons plugin API states that one must print at least one line of
output to stdout. Previous to this commit, only output to stderr would
be printed on errors, which meant the plugin did not conform to the
plugin standard.

With this commit we print everything to stdout.

This fixes: MON-12456

Signed-off-by: Jacob Hansen <jhansen@op5.com>