### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     reviewers:
       - "ITRS-Group/team-b"


### PR DESCRIPTION
We now run dependabot once every week, on sundays.

Signed-off-by: Daniel Nilsson <dnilsson@itrsgroup.com>