### PR TITLE
Allow specifying multiple namespaces in a single run, and accept pods in "Completed" status as a Good state instead of failure

### DIFF
--- a/check_k8s.py
+++ b/check_k8s.py
@@ -22,37 +22,41 @@ def main():
 
     health_check, is_core = MAPPINGS[parsed.resource]
 
-    # Build URL using input arguments
-    url = build_url(
-        host=parsed.host,
-        port=parsed.port,
-        resource=parsed.resource,
-        is_core=is_core,
-        namespace=parsed.namespace
-    )
+    response = []
+    for i in parsed.namespace.split(","):
 
+      # Build URL using input arguments
+      url = build_url(
+          host=parsed.host,
+          port=parsed.port,
+          resource=parsed.resource,
+          is_core=is_core,
+          namespace=i
+      )
     # Request and check health data
-    try:
-        response, status = request(url, token=parsed.token, insecure=parsed.insecure)
-        output = health_check(response).output
-        if not isinstance(output, Output):
-            raise TypeError("Unknown health check format")
-    except HTTPError as e:
-        body = json.loads(e.read().decode("utf8"))
-        output = Output(
-            NaemonState.UNKNOWN,
-            "{0}: {1}".format(e.code, body.get("message")),
-            sys.stdout
-        )
-    except URLError as e:
-        output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
-    except Exception as e:
-        if parsed.debug:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            traceback.print_tb(exc_traceback, file=sys.stdout)
+      try:
+          response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
+          response.extend(response_single);
+      except HTTPError as e:
+          body = json.loads(e.read().decode("utf8"))
+          output = Output(
+              NaemonState.UNKNOWN,
+              "{0}: {1}".format(e.code, body.get("message")),
+              sys.stdout
+          )
+      except URLError as e:
+          output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
+      except Exception as e:
+          if parsed.debug:
+              exc_type, exc_value, exc_traceback = sys.exc_info()
+              traceback.print_tb(exc_traceback, file=sys.stdout)
+          output = Output(NaemonState.UNKNOWN, e, sys.stdout)
 
-        output = Output(NaemonState.UNKNOWN, e, sys.stdout)
 
+
+    output = health_check(response).output
+    if not isinstance(output, Output):
+      raise TypeError("Unknown health check format")
     msg = NAGIOS_MSG.format(state=output.state.name, message=output.message)
     output.channel.write(msg)
     sys.exit(output.state.value)

--- a/check_k8s.py
+++ b/check_k8s.py
@@ -46,7 +46,6 @@ def main():
       ))
       # Request and check health data
     for url in urls:
-        print(f"{url}\n")
         try:
             response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
             response.extend(response_single);

--- a/check_k8s.py
+++ b/check_k8s.py
@@ -23,35 +23,62 @@ def main():
     health_check, is_core = MAPPINGS[parsed.resource]
 
     response = []
-    for i in parsed.namespace.split(","):
-
-      # Build URL using input arguments
-      url = build_url(
-          host=parsed.host,
-          port=parsed.port,
-          resource=parsed.resource,
-          is_core=is_core,
-          namespace=i
-      )
-    # Request and check health data
-      try:
-          response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
-          response.extend(response_single);
-      except HTTPError as e:
-          body = json.loads(e.read().decode("utf8"))
-          output = Output(
-              NaemonState.UNKNOWN,
-              "{0}: {1}".format(e.code, body.get("message")),
-              sys.stdout
-          )
-      except URLError as e:
-          output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
-      except Exception as e:
-          if parsed.debug:
-              exc_type, exc_value, exc_traceback = sys.exc_info()
-              traceback.print_tb(exc_traceback, file=sys.stdout)
-          output = Output(NaemonState.UNKNOWN, e, sys.stdout)
-
+    if parsed.namespace is not None:
+      for i in parsed.namespace.split(","):
+  
+        # Build URL using input arguments
+        url = build_url(
+            host=parsed.host,
+            port=parsed.port,
+            resource=parsed.resource,
+            is_core=is_core,
+            namespace=i
+        )
+      # Request and check health data
+        try:
+            response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
+            response.extend(response_single);
+        except HTTPError as e:
+            body = json.loads(e.read().decode("utf8"))
+            output = Output(
+                NaemonState.UNKNOWN,
+                "{0}: {1}".format(e.code, body.get("message")),
+                sys.stdout
+            )
+        except URLError as e:
+            output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
+        except Exception as e:
+            if parsed.debug:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                traceback.print_tb(exc_traceback, file=sys.stdout)
+            output = Output(NaemonState.UNKNOWN, e, sys.stdout)
+    else:
+        # Build URL using input arguments
+        url = build_url(
+            host=parsed.host,
+            port=parsed.port,
+            resource=parsed.resource,
+            is_core=is_core,
+            namespace=None
+        )
+      # Request and check health data
+        try:
+            response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
+            response.extend(response_single);
+        except HTTPError as e:
+            body = json.loads(e.read().decode("utf8"))
+            output = Output(
+                NaemonState.UNKNOWN,
+                "{0}: {1}".format(e.code, body.get("message")),
+                sys.stdout
+            )
+        except URLError as e:
+            output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
+        except Exception as e:
+            if parsed.debug:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                traceback.print_tb(exc_traceback, file=sys.stdout)
+            output = Output(NaemonState.UNKNOWN, e, sys.stdout)
 
 
     output = health_check(response).output

--- a/check_k8s.py
+++ b/check_k8s.py
@@ -23,45 +23,30 @@ def main():
     health_check, is_core = MAPPINGS[parsed.resource]
 
     response = []
+    urls = []
     if parsed.namespace is not None:
       for i in parsed.namespace.split(","):
   
         # Build URL using input arguments
-        url = build_url(
+        urls.append(build_url(
             host=parsed.host,
             port=parsed.port,
             resource=parsed.resource,
             is_core=is_core,
             namespace=i
-        )
-      # Request and check health data
-        try:
-            response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
-            response.extend(response_single);
-        except HTTPError as e:
-            body = json.loads(e.read().decode("utf8"))
-            output = Output(
-                NaemonState.UNKNOWN,
-                "{0}: {1}".format(e.code, body.get("message")),
-                sys.stdout
-            )
-        except URLError as e:
-            output = Output(NaemonState.UNKNOWN, e.reason, sys.stdout)
-        except Exception as e:
-            if parsed.debug:
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                traceback.print_tb(exc_traceback, file=sys.stdout)
-            output = Output(NaemonState.UNKNOWN, e, sys.stdout)
+        ))
     else:
-        # Build URL using input arguments
-        url = build_url(
-            host=parsed.host,
-            port=parsed.port,
-            resource=parsed.resource,
-            is_core=is_core,
-            namespace=None
-        )
+      # Build URL using input arguments
+      urls.append(build_url(
+          host=parsed.host,
+          port=parsed.port,
+          resource=parsed.resource,
+          is_core=is_core,
+          namespace=None
+      ))
       # Request and check health data
+    for url in urls:
+        print(f"{url}\n")
         try:
             response_single, status = request(url, token=parsed.token, insecure=parsed.insecure)
             response.extend(response_single);

--- a/k8s/components/pod/resource.py
+++ b/k8s/components/pod/resource.py
@@ -41,6 +41,10 @@ class Pod(Resource):
         elif cnd_type in STATUSES:
             if cnd_status == "True":
                 return NaemonStatus(NaemonState.OK, self.perf.AVAILABLE)
+            # YV - adding this when the phase is Succeeded
+            # This happens when the pod is not running since it's already completed
+            elif cnd_status and self.phase == Phase.succeeded:
+                return NaemonStatus(NaemonState.OK, self.perf.AVAILABLE)
             else:
                 return NaemonStatus(NaemonState.CRITICAL, self.perf.UNAVAILABLE)
         elif cnd_type not in STATUSES and cnd_status == "True":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ def test_opts():
         return parse_cmdline(["--resource", "nodes"] + args)
 
     assert parser(["--namespace", "test"]).namespace == "test"
+    assert parser(["--namespace", "test,test2,test3"]).namespace == "test,test2,test3"
     assert parser(["--debug"]).debug is True
     assert parser(["--insecure"]).insecure is True
     assert parser(["--timeout", "123.0"]).timeout == 123.0


### PR DESCRIPTION
Added capability to add comma-separated namespaces to the `--namespace` option for a multi-namespace check (necessary for projects where a single application is spread across multiple namespaces for whatever developer reasons are provided) as such:

`--namespace "namespace1,namespace2,namespace3"`

Additional fix added by yvarbanov for acknowledging pods in "Completed" as successful in pods.py - the script was reporting those as failed even though they had successfully finished their run and were terminated and causing the monitor to show failures to show in namespaces where all pods were in good states.


To utilize this function in Icinga2, for example, the following code can be used to apply the monitoring capability to a cluster:

 **Host Entry**
```
object Host "OpenShift K8s Cluster A" {
    check_command = "dummy"
    vars.address = "openshift.example.com"
    vars.bastion_address = "jumphost." + vars.address
    vars.api_address = "api." + vars.address
    vars.dummy_state = 0
    vars.bastion_user = "bastion-user"
    vars.http_port = "6443"
    enable_passive_checks = false
    vars.ocp_infra_namespace_groups = {
         Application1 = "app1web,app1db,app1int"
         Application2 = "app2web,app2db,app2int"
         OCP_Core = "openshift-authentication,openshift-apiserver,openshift-cloud-credential-operator,openshift-machine-api,openshift-config-operator,openshift-console,openshift-cluster-storage-operator"
    }
    vars.client_endpoint = name
    vars.hosttype = "infra_ocp"
    vars.hostenv = "production"
    vars.notification.mail.groups = [ "icingaadmins" ]
}
```

**Service Config**
```
apply Service "OCP Infra Service " for (key => value in host.vars.ocp_infra_namespace_groups) to Host  {
    import "generic_service_babylon_ocp"
    check_command = "check_k8s_pods"
    vars.api_url = "$host.vars.api_address$"
    vars.api_port = "$host.vars.http_port$"
    vars.ocp_namespace = value
    vars.serviceenv = "$host.vars.hostenv$"
    assign where ( match("infra_ocp*", host.vars.hosttype) )
}
```