### PR TITLE
Add command line paramerer to exclude specified resource names from the check result

### DIFF
--- a/check_k8s.py
+++ b/check_k8s.py
@@ -55,7 +55,7 @@ def main():
                 url, token=parsed.token, insecure=parsed.insecure
             )
             response.extend(response_single)
-        output = health_check(response).output
+        output = health_check(response, parsed.expressions).output
         if not isinstance(output, Output):
             raise TypeError("Unknown health check format")
     except HTTPError as e:

--- a/k8s/cli.py
+++ b/k8s/cli.py
@@ -16,6 +16,7 @@ class Default(Enum):
     debug = False
     namespace = None
     resource = None
+    ignore = None
 
 
 opts = [
@@ -110,6 +111,19 @@ opts = [
             "default": Default.namespace.value,
             "required": False,
             "help": "Look only within this namespace",
+        },
+    ),
+    (
+        "--ignore",
+        {
+            "dest": "expressions",
+            "action": "append",
+            "type": str,
+            "default": Default.ignore.value,
+            "required": False,
+            "help": "Regular Expression to match against\
+                    the resource names to ignore in the check results.\
+                    Can be invoked multiple times.",
         },
     ),
     (

--- a/k8s/components/deployment/check.py
+++ b/k8s/components/deployment/check.py
@@ -3,7 +3,7 @@ from k8s.result import Result
 from .resource import Deployment
 
 
-def check_deployments(items):
+def check_deployments(items, expressions):
     """Checks the health of the provided Deployments
 
     Documentation:
@@ -14,4 +14,4 @@ def check_deployments(items):
     :return: Deployments health summary
     """
 
-    return Result(Deployment, items)
+    return Result(Deployment, items, expressions)

--- a/k8s/components/node/check.py
+++ b/k8s/components/node/check.py
@@ -3,7 +3,7 @@ from k8s.result import Result
 from .resource import Node
 
 
-def check_nodes(items):
+def check_nodes(items, expressions):
     """Checks the health of the provided Nodes
 
     Documentation:
@@ -14,4 +14,4 @@ def check_nodes(items):
     :return: Nodes health summary
     """
 
-    return Result(Node, items)
+    return Result(Node, items, expressions)

--- a/k8s/components/pod/check.py
+++ b/k8s/components/pod/check.py
@@ -3,7 +3,7 @@ from k8s.result import Result
 from .resource import Pod
 
 
-def check_pods(items):
+def check_pods(items, expressions):
     """Check health of one or more Pods and associated Containers
 
     Documentation:
@@ -14,4 +14,4 @@ def check_pods(items):
     :return: Pods health summary
     """
 
-    return Result(Pod, items)
+    return Result(Pod, items, expressions)

--- a/k8s/consts.py
+++ b/k8s/consts.py
@@ -7,7 +7,7 @@ RESULT_SUCCESS = "All checks were successful"
 RESULT_CRITICAL = "One or more errors encountered"
 RESULT_WARNING = "One or more warnings encountered"
 
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 
 class NaemonState(Enum):

--- a/k8s/ignore.py
+++ b/k8s/ignore.py
@@ -1,0 +1,22 @@
+import re
+import logging
+
+resource_pattern = re.compile(r"\S+:{1}")
+
+
+def get_expression_pattern(expressions):
+    expression_patterns = []
+    if expressions:
+        for expression in expressions:
+            expression_patterns.append(re.compile(r"{}".format(expression)))
+    return expression_patterns
+
+
+def is_ignored_resource(line, expressions):
+    word = re.search(resource_pattern, line)
+    for expression in expressions:
+        found = re.search(expression, word.group())
+        if found:
+            logging.debug("Ignoring results for " + word.group())
+            return True
+    return False

--- a/k8s/result.py
+++ b/k8s/result.py
@@ -9,14 +9,16 @@ from k8s.consts import (
     RESULT_CRITICAL,
     RESULT_WARNING,
 )
+from k8s.ignore import get_expression_pattern, is_ignored_resource
 
 Output = namedtuple("Output", ["state", "message", "channel"])
 
 
 class Result:
-    def __init__(self, cls, items):
+    def __init__(self, cls, items, expressions):
         self._messages = {}
         self._perfdata = {v.value: 0 for v in cls.PerfMap}
+        self._expression_patterns = get_expression_pattern(expressions)
         self._register_conditions([cls(i).condition for i in items])
 
     def _register_conditions(self, conditions):
@@ -26,6 +28,9 @@ class Result:
         """
 
         for message, status in conditions:
+            # Skip adding to result if resource is in ignore list
+            if is_ignored_resource(message, self._expression_patterns):
+                continue
             if status.state not in self._messages:
                 self._messages[status.state] = []
 
@@ -53,11 +58,18 @@ class Result:
         :return: Output object
         """
 
-        message = "{0}\n{conditions}|{perfdata}\n".format(
-            summary,
-            conditions="\n".join(self._messages[state]),
-            perfdata=PERFDATA_SEPARATOR.join(self.perfdata),
-        )
+        # messages can be empty if all are ignored
+        if len(self._messages):
+            message = "{0}\n{conditions}|{perfdata}\n".format(
+                summary,
+                conditions="\n".join(self._messages[state]),
+                perfdata=PERFDATA_SEPARATOR.join(self.perfdata),
+            )
+        else:
+            message = "{0}\n|{perfdata}\n".format(
+                summary,
+                perfdata=PERFDATA_SEPARATOR.join(self.perfdata),
+            )
         return Output(state, message, channel)
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check_k8s"
-version = "1.0.0"
+version = "1.1.0"
 description = "Kubernetes monitoring plugin"
 authors = ["Robert Wikman <rwikman@op5.com>"]
 license = "GPL-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -672,3 +672,23 @@ def deployment_full(deployment_base, deployment_conditions, deployment_replicas_
     deployment_base["status"]["conditions"] = deployment_conditions
     deployment_base["status"].update(deployment_replicas_minimal)
     return deployment_base
+
+
+@pytest.fixture
+def ignore_none():
+    return []
+
+
+@pytest.fixture
+def ignore_all_node(node_base):
+    return [node_base["metadata"]["name"]]
+
+
+@pytest.fixture
+def ignore_all_deployment(deployment_base):
+    return [deployment_base["metadata"]["name"]]
+
+
+@pytest.fixture
+def ignore_all_pod(pod_base):
+    return [pod_base["metadata"]["name"]]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ def test_opts():
     assert parser(["--timeout", "123.0"]).timeout == 123.0
     assert parser(["--port", "1234"]).port == 1234
     assert parser(["--token", "token123"]).token == "token123"
+    assert parser(["--ignore", "IgnoreResource", "--ignore", "IgnoreResourceAgain"]).expressions == ["IgnoreResource", "IgnoreResourceAgain"]
     assert parser([]).debug is Default.debug.value
     assert parser([]).insecure is Default.insecure.value
     assert parser([]).timeout is Default.timeout.value

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -18,13 +18,13 @@ def test_kind(deployment_full):
     assert Deployment(deployment_full)._kind == "Deployment"
 
 
-def test_result(deployment_full):
-    result = check_deployments([deployment_full])
+def test_result(deployment_full, ignore_none):
+    result = check_deployments([deployment_full], ignore_none)
     assert isinstance(result, Result)
 
 
-def test_output(deployment_full):
-    output = check_deployments([deployment_full]).output
+def test_output(deployment_full, ignore_none):
+    output = check_deployments([deployment_full], ignore_none).output
     assert isinstance(output, Output)
 
 
@@ -38,21 +38,48 @@ def test_replicas(deployment_full):
     assert replicas.updated == replica_data["updatedReplicas"]
 
 
-def test_replicas_unavailable(deployment_full):
+def test_replicas_available(deployment_full, ignore_none):
+    output = check_deployments([deployment_full], ignore_none).output
+    assert output.state == NaemonState.OK
+
+
+def test_replicas_ignored(deployment_full, ignore_none):
+    output = check_deployments([deployment_full], ignore_none).output
+    assert output.state == NaemonState.OK
+
+
+def test_replicas_unavailable(deployment_full, ignore_none):
     replicas = deployment_full["status"]
     replicas["availableReplicas"] = 0
-    output = check_deployments([deployment_full]).output
+    output = check_deployments([deployment_full], ignore_none).output
     assert output.state == NaemonState.CRITICAL
 
 
-def test_replicas_not_updated(deployment_full):
+def test_replicas_not_updated(deployment_full, ignore_none):
     replicas = deployment_full["status"]
     replicas["updatedReplicas"] = 0
-    output = check_deployments([deployment_full]).output
+    output = check_deployments([deployment_full], ignore_none).output
     assert output.state == NaemonState.CRITICAL
 
 
-def test_replicas_degraded(deployment_full, deployment_replicas_degraded):
+def test_replicas_not_updated_ignored(deployment_full, ignore_all_deployment):
+    replicas = deployment_full["status"]
+    replicas["updatedReplicas"] = 0
+    output = check_deployments([deployment_full], ignore_all_deployment).output
+    lines = output.message.split('\n')
+    assert output.state == NaemonState.OK
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 noreps=0"
+
+
+def test_replicas_degraded(deployment_full, deployment_replicas_degraded, ignore_none):
     deployment_full["status"].update(deployment_replicas_degraded)
-    output = check_deployments([deployment_full]).output
+    output = check_deployments([deployment_full], ignore_none).output
     assert output.state == NaemonState.WARNING
+
+
+def test_replicas_degraded_ignored(deployment_full, deployment_replicas_degraded, ignore_all_deployment):
+    deployment_full["status"].update(deployment_replicas_degraded)
+    output = check_deployments([deployment_full], ignore_all_deployment).output
+    lines = output.message.split('\n')
+    assert output.state == NaemonState.OK
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 noreps=0"

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,66 @@
+import pytest
+import logging
+
+from k8s.ignore import get_expression_pattern,is_ignored_resource
+
+
+message = ["Pod name: some message",
+"Pod multiple1: some message",
+"Pod multiple2: some message",
+"Pod some other text diff_position: some message",
+"Pod with_symbols,;-!: some message"]
+
+def ignore_from_list(lines, expressions):
+    count = 0
+    expression_patterns = get_expression_pattern(expressions)
+    for line in lines:
+        if(is_ignored_resource(line, expression_patterns)):
+            count+=1
+    return count
+
+
+def test_ignore_resource_single(caplog):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    count = ignore_from_list(message, ["name"])
+    assert "name:" in caplog.text
+    assert count == 1
+
+
+def test_ignore_resource_multiple(caplog):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    count = ignore_from_list(message, ["multiple"])
+    assert "multiple1:" in caplog.text
+    assert "multiple2:" in caplog.text
+    assert count == 2
+
+
+def test_ignore_different_position(caplog):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    count = ignore_from_list(message, ["diff_position"])
+    assert "diff_position:" in caplog.text
+    assert count == 1
+
+
+def test_ignore_with_symbol(caplog):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    count = ignore_from_list(message, ["with_symbols,;-!"])
+    assert "with_symbols,;-!" in caplog.text
+    assert count == 1
+
+
+def test_ignore_all(caplog):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    count = ignore_from_list(message, ["name", "multiple", "diff_position", "with_symbols,;-!"])
+    assert count == 5
+
+
+def test_ignore_all_regex(caplog):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+    count = ignore_from_list(message, ["\S*"]) 
+    assert count == 5

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -8,26 +8,50 @@ def test_kind(node_full):
     assert Node(node_full)._kind == "Node"
 
 
-def test_result(node_full):
-    result = check_nodes([node_full])
+def test_result(node_full, ignore_none):
+    result = check_nodes([node_full], ignore_none)
     assert isinstance(result, Result)
 
 
-def test_output(node_full):
-    output = check_nodes([node_full]).output
+def test_output(node_full, ignore_none):
+    output = check_nodes([node_full], ignore_none).output
     assert isinstance(output, Output)
 
 
-def test_ready(node_base, node_ready):
+def test_ready(node_base, node_ready, ignore_none):
     node_base["status"]["conditions"] = node_ready
-    assert check_nodes([node_base]).output.message.startswith(RESULT_SUCCESS)
+    assert check_nodes([node_base], ignore_none).output.message.startswith(RESULT_SUCCESS)
 
 
-def test_not_ready(node_base, node_not_ready):
+def test_ignore_ready(node_base, node_ready, ignore_all_node):
+    node_base["status"]["conditions"] = node_ready
+    message = check_nodes([node_base], ignore_all_node).output.message
+    lines = message.split('\n')
+    assert lines[0] == RESULT_SUCCESS
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 unschedulable=0"
+
+
+def test_not_ready(node_base, node_not_ready, ignore_none):
     node_base["status"]["conditions"] = node_not_ready
-    assert check_nodes([node_base]).output.message.startswith(RESULT_CRITICAL)
+    assert check_nodes([node_base], ignore_none).output.message.startswith(RESULT_CRITICAL)
 
 
-def test_memory_pressure(node_base, node_memory_pressure):
+def test_ignored_not_ready(node_base, node_not_ready, ignore_all_node):
+    node_base["status"]["conditions"] = node_not_ready
+    message = check_nodes([node_base], ignore_all_node).output.message
+    lines = message.split('\n')
+    assert lines[0] == RESULT_SUCCESS
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 unschedulable=0"
+
+
+def test_memory_pressure(node_base, node_memory_pressure, ignore_none):
     node_base["status"]["conditions"] = node_memory_pressure
-    assert check_nodes([node_base]).output.message.startswith(RESULT_WARNING)
+    assert check_nodes([node_base], ignore_none).output.message.startswith(RESULT_WARNING)
+
+
+def test_ignored_memory_pressure(node_base, node_memory_pressure, ignore_all_node):
+    node_base["status"]["conditions"] = node_memory_pressure
+    message = check_nodes([node_base], ignore_all_node).output.message
+    lines = message.split('\n')
+    assert lines[0] == RESULT_SUCCESS
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 unschedulable=0"

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -40,27 +40,54 @@ def test_container_count(pod_full, pod_containers):
     assert len(Pod(pod_full).containers) == len(pod_containers)
 
 
-def test_check_pending(pod_full):
+def test_check_pending(pod_full, ignore_none):
     pod_full["status"]["phase"] = "Pending"
-    assert check_pods([pod_full]).output.state == NaemonState.CRITICAL
+    assert check_pods([pod_full], ignore_none).output.state == NaemonState.CRITICAL
 
 
-def test_check_failed(pod_full):
+def test_check_failed(pod_full, ignore_none):
     pod_full["status"]["phase"] = "Failed"
-    assert check_pods([pod_full]).output.state == NaemonState.CRITICAL
+    assert check_pods([pod_full], ignore_none).output.state == NaemonState.CRITICAL
 
 
-def test_check_not_running(pod_base, pod_not_ready, pod_containers):
+def test_check_not_running(pod_base, pod_not_ready, pod_containers, ignore_none):
     pod_base["status"]["conditions"] = pod_not_ready
     pod_base["status"]["containerStatuses"] = pod_containers
-    assert check_pods([pod_base]).output.state == NaemonState.CRITICAL
+    assert check_pods([pod_base], ignore_none).output.state == NaemonState.CRITICAL
 
 
-def test_check_cond_other(pod_base, pod_condition_other, pod_containers):
+def test_check_not_running_ignored(pod_base, pod_not_ready, pod_containers, ignore_all_pod):
+    pod_base["status"]["conditions"] = pod_not_ready
+    pod_base["status"]["containerStatuses"] = pod_containers
+    output = check_pods([pod_base], ignore_all_pod).output
+    lines = output.message.split('\n')
+    assert output.state == NaemonState.OK
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 pending=0"
+
+
+def test_check_cond_other(pod_base, pod_condition_other, pod_containers, ignore_none):
     pod_base["status"]["conditions"] = pod_condition_other
     pod_base["status"]["containerStatuses"] = pod_containers
-    assert check_pods([pod_base]).output.state == NaemonState.WARNING
+    assert check_pods([pod_base], ignore_none).output.state == NaemonState.WARNING
 
-def test_check_succeeded(pod_full):
+
+def test_check_cond_other_ignored(pod_base, pod_condition_other, pod_containers, ignore_all_pod):
+    pod_base["status"]["conditions"] = pod_condition_other
+    pod_base["status"]["containerStatuses"] = pod_containers
+    output = check_pods([pod_base], ignore_all_pod).output
+    lines = output.message.split('\n')
+    assert output.state == NaemonState.OK
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 pending=0"
+
+
+def test_check_succeeded(pod_full, ignore_none):
     pod_full["status"]["phase"] = "Succeeded"
-    assert check_pods([pod_full]).output.state == NaemonState.OK
+    assert check_pods([pod_full], ignore_none).output.state == NaemonState.OK
+
+
+def test_check_succeeded_ignored(pod_full, ignore_all_pod):
+    pod_full["status"]["phase"] = "Succeeded"
+    output = check_pods([pod_full], ignore_all_pod).output
+    lines = output.message.split('\n')
+    assert output.state == NaemonState.OK
+    assert lines[1] == "|available=0 unavailable=0 degraded=0 pending=0"


### PR DESCRIPTION
This commit adds the --ignore command line parameter to enable the users
to ignore or exclude specified resource names from being included in the
check result. The ignored resoures will not affect the final status being
reported by the plugin. The --ignore takes a regular expression  and uses 
python's re module to evaluate which resources will be ignored. 

This resolves MON-13152.

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>