### PR TITLE
Handle json decode errors

### DIFF
--- a/check_k8s.py
+++ b/check_k8s.py
@@ -59,10 +59,13 @@ def main():
         if not isinstance(output, Output):
             raise TypeError("Unknown health check format")
     except HTTPError as e:
-        body = json.loads(e.read().decode("utf8"))
+        try:
+            msg = json.loads(e.read().decode("utf8")).get("message")
+        except json.JSONDecodeError:
+            msg = e.reason
         output = Output(
             NaemonState.UNKNOWN,
-            "{0}: {1}".format(e.code, body.get("message")),
+            "{0}: {1}".format(e.code, msg),
             sys.stdout,
         )
     except URLError as e:

--- a/check_k8s.py
+++ b/check_k8s.py
@@ -9,7 +9,7 @@ from urllib.error import URLError, HTTPError
 
 from k8s.components import MAPPINGS
 from k8s.cli import parse_cmdline
-from k8s.http import build_url, request
+from k8s.http import build_url, handle_http_error, make_requests
 from k8s.consts import NAGIOS_MSG, NaemonState
 from k8s.result import Output
 
@@ -22,7 +22,7 @@ def main():
 
     health_check, is_core = MAPPINGS[parsed.resource]
 
-    response = []
+    output = []
     urls = []
     if parsed.namespace is not None:
         for i in parsed.namespace.split(","):
@@ -50,19 +50,9 @@ def main():
         )
     # Request and check health data
     try:
-        for url in urls:
-            response_single, status = request(
-                url, token=parsed.token, insecure=parsed.insecure
-            )
-            response.extend(response_single)
-        output = health_check(response).output
-        if not isinstance(output, Output):
-            raise TypeError("Unknown health check format")
+        output = make_requests(urls, parsed, health_check)
     except HTTPError as e:
-        try:
-            msg = json.loads(e.read().decode("utf8")).get("message")
-        except json.JSONDecodeError:
-            msg = e.reason
+        msg = handle_http_error(e)
         output = Output(
             NaemonState.UNKNOWN,
             "{0}: {1}".format(e.code, msg),

--- a/k8s/http.py
+++ b/k8s/http.py
@@ -3,6 +3,7 @@ import os
 import json
 import ssl
 import urllib.request
+from k8s.result import Output
 
 
 def build_url(host, port, resource, is_core=True, namespace=None):
@@ -60,3 +61,27 @@ def request(*args, insecure=False, **kwargs):
 
     resp = urllib.request.urlopen(req, **urlopen_opts)
     return json.loads(resp.read().decode("utf-8")).get("items"), resp.getcode()
+
+
+def make_requests(urls, parsed, health_check):
+    response = []
+    output = ""
+    for url in urls:
+        response_single, status = request(
+            url, token=parsed.token, insecure=parsed.insecure
+        )
+        response.extend(response_single)
+    output = health_check(response).output
+    if not isinstance(output, Output):
+        raise TypeError("Unknown health check format")
+    return output
+
+
+def handle_http_error(e):
+    msg = ""
+    try:
+        msg = json.loads(e.read().decode("utf8")).get("message")
+    except json.JSONDecodeError:
+        msg = e.reason
+
+    return msg

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,9 @@
+from unittest.mock import create_autospec
 import pytest
+import json
 
-from k8s.http import build_url, _request_prepare
+from urllib.error import HTTPError
+from k8s.http import build_url, _request_prepare, handle_http_error
 
 
 def test_core_url():
@@ -15,12 +18,16 @@ def test_app_url():
 
 def test_namespaced_app():
     expected = "https://host:1234/apis/apps/v1/namespaces/test/resource"
-    assert build_url("host", 1234, "resource", is_core=False, namespace="test") == expected
+    assert (
+        build_url("host", 1234, "resource", is_core=False, namespace="test") == expected
+    )
 
 
 def test_namespaced_core():
     expected = "https://host:1234/api/v1/namespaces/test/resource"
-    assert build_url("host", 1234, "resource", is_core=True, namespace="test") == expected
+    assert (
+        build_url("host", 1234, "resource", is_core=True, namespace="test") == expected
+    )
 
 
 def test_request_invalid_url():
@@ -29,6 +36,17 @@ def test_request_invalid_url():
 
 
 def test_authenticated_request():
-    request = _request_prepare("https://kubernetes:1234/api/v1/resource", token="of_zeh_tokens")
+    request = _request_prepare(
+        "https://kubernetes:1234/api/v1/resource", token="of_zeh_tokens"
+    )
     assert request.headers["Authorization"] == "Bearer of_zeh_tokens"
 
+def read():
+    raise json.JSONDecodeError("test", "test", 1)
+
+def test_json_decode():
+    mock = create_autospec(HTTPError)
+    mock.read = read
+    mock.reason = "HTTPError reason"
+
+    assert handle_http_error(mock) == "HTTPError reason"


### PR DESCRIPTION
Added a try/catch to look for JsonDecode errors.

Also moved certain functionality to separate functions for testability and added a small test to
check that we handle json decode errors correctly.

This solves: MON-13160

Co-authored-by: Erik Sjöström<esjostrom@itrsgroup.com>
Signed-off-by: Axel Bolle <abolle@itrsgroup.com>