### PR TITLE
Improve kubernetes management pack

### DIFF
--- a/op5build/check_k8s.metadata
+++ b/op5build/check_k8s.metadata
@@ -1,8 +1,3 @@
-[commands]
-check_k8s_nodes=$USER1$/check_k8s.py --resource nodes --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$
-check_k8s_pods=$USER1$/check_k8s.py --resource pods --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$ --namespace $ARG5$
-check_k8s_deployments=$USER1$/check_k8s.py --resource deployments --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$ --namespace $ARG5$
-
 [name]
 check_k8s
 

--- a/op5build/check_k8s.metadata
+++ b/op5build/check_k8s.metadata
@@ -1,5 +1,5 @@
 [commands]
-check_k8s_nodes=$USER1$/check_k8s.py --resource nodes --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$ --namespace $ARG5$
+check_k8s_nodes=$USER1$/check_k8s.py --resource nodes --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$
 check_k8s_pods=$USER1$/check_k8s.py --resource pods --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$ --namespace $ARG5$
 check_k8s_deployments=$USER1$/check_k8s.py --resource deployments --host $ARG1$ --port $ARG2$ --token $ARG3$ --token_file $ARG4$ --namespace $ARG5$
 


### PR DESCRIPTION
This commit remove the checkcommands from the metadata.  The Kubernetes checkcommands are now defined in the  Kubernetes management pack.

Part of MON-13166.

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>