### PR TITLE
Add option to filter by labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ check_k8s: Kubernetes plugin for Nagios
 
 Nagios plugin for monitoring Kubernetes Clusters, built using the Python standard library.
 
-It currently supports monitoring of *Pods*, *Nodes* and *Deployments*. 
+It currently supports monitoring of *Pods*, *Nodes* and *Deployments*.
 
 Usage
 ===
@@ -17,6 +17,8 @@ usage: check_k8s.py [-h] [--host HOST] [--token TOKEN]
                     [--token_file TOKEN_FILE] [--port PORT]
                     [--timeout TIMEOUT] [--insecure] [--debug] --resource
                     {pods,nodes,deployments} [--namespace NAMESPACE]
+                    [--ignore EXPRESSIONS] [--selector SELECTOR]
+                    [--version]
 
 Checks health of a Kubernetes cluster
 
@@ -34,6 +36,10 @@ optional arguments:
                         Resource to monitor
   --namespace NAMESPACE
                         Look only within this namespace
+  --ignore EXPRESSIONS  Regular Expression to match against the resource
+                        names to ignore in the check results. Can be
+                        invoked multiple times.
+  --selector SELECTOR   Label selector query to be used.
   --version             show program's version number and exit
 
 ```

--- a/check_k8s.py
+++ b/check_k8s.py
@@ -35,6 +35,7 @@ def main():
                     resource=parsed.resource,
                     is_core=is_core,
                     namespace=i,
+                    labelSelector=parsed.selector,
                 )
             )
     else:
@@ -46,6 +47,7 @@ def main():
                 resource=parsed.resource,
                 is_core=is_core,
                 namespace=None,
+                labelSelector=parsed.selector,
             )
         )
     # Request and check health data

--- a/k8s/cli.py
+++ b/k8s/cli.py
@@ -17,6 +17,7 @@ class Default(Enum):
     namespace = None
     resource = None
     ignore = None
+    selector = None
 
 
 opts = [
@@ -124,6 +125,17 @@ opts = [
             "help": "Regular Expression to match against\
                     the resource names to ignore in the check results.\
                     Can be invoked multiple times.",
+        },
+    ),
+    (
+        "--selector",
+        {
+            "dest": "selector",
+            "action": "store",
+            "type": str,
+            "default": Default.selector.value,
+            "required": False,
+            "help": "Label selector query to be used.",
         },
     ),
     (

--- a/k8s/http.py
+++ b/k8s/http.py
@@ -3,9 +3,10 @@ import os
 import json
 import ssl
 import urllib.request
+import urllib.parse
 
 
-def build_url(host, port, resource, is_core=True, namespace=None):
+def build_url(host, port, resource, is_core=True, namespace=None, labelSelector=None):
     """Kubernetes URL builder
 
     :param host: Kubernetes host
@@ -18,6 +19,10 @@ def build_url(host, port, resource, is_core=True, namespace=None):
     path_base = "api/v1" if is_core else "apis/apps/v1"
     path_parts = ["namespaces", namespace, resource] if namespace else (resource,)
     path_full = re.sub(r"/+", "/", os.path.join(path_base, *path_parts).rstrip("/"))
+
+    if labelSelector:
+        labelSelector = "?labelSelector=" + urllib.parse.quote_plus(labelSelector)
+        path_full += labelSelector
 
     return "https://{0}:{1}/{2}".format(host, port, path_full)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,11 +35,14 @@ def test_opts():
     assert parser(["--port", "1234"]).port == 1234
     assert parser(["--token", "token123"]).token == "token123"
     assert parser(["--ignore", "IgnoreResource", "--ignore", "IgnoreResourceAgain"]).expressions == ["IgnoreResource", "IgnoreResourceAgain"]
+    assert parser(["--selector", "test"]).selector == "test"
     assert parser([]).debug is Default.debug.value
     assert parser([]).insecure is Default.insecure.value
     assert parser([]).timeout is Default.timeout.value
     assert parser([]).port is Default.port.value
     assert parser([]).host is Default.host.value
+    assert parser([]).expressions is Default.ignore.value
+    assert parser([]).selector is Default.selector.value
 
 
 def test_token_file():

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -32,3 +32,45 @@ def test_authenticated_request():
     request = _request_prepare("https://kubernetes:1234/api/v1/resource", token="of_zeh_tokens")
     assert request.headers["Authorization"] == "Bearer of_zeh_tokens"
 
+
+def test_labelSelector_equality_based_equal():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=key%3Dvalue"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="key=value") == expected
+
+
+def test_labelSelector_equality_based_double_equal():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=key%3D%3Dvalue"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="key==value") == expected
+
+
+def test_labelSelector_equality_based_not_equal():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=key%21%3Dvalue"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="key!=value") == expected
+
+
+def test_labelSelector_set_based_in():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=key+in+%28value%29"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="key in (value)") == expected
+
+
+def test_labelSelector_set_based_notin():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=key+notin+%28value1%2C+value2%29"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="key notin (value1, value2)") == expected
+
+
+def test_labelSelector_set_based_key():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=key"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="key") == expected
+
+
+def test_labelSelector_set_based_not_key():
+    expected = "https://host:1234/api/v1/namespaces/test/resource?labelSelector=%21key"
+    assert build_url("host", 1234, "resource", is_core=True, namespace="test",
+        labelSelector="!key") == expected
+


### PR DESCRIPTION
This commit adds the --selector option to filter out objects using
labels. The string input provided by the user will be appended to
the kubernetes API as a labelSelector query.

This resolves MON-13168.

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>