### PR TITLE
Fix missing parameter in call to check_health function

### DIFF
--- a/k8s/http.py
+++ b/k8s/http.py
@@ -76,7 +76,7 @@ def make_requests(urls, parsed, health_check):
             url, token=parsed.token, insecure=parsed.insecure
         )
         response.extend(response_single)
-    output = health_check(response).output
+    output = health_check(response, parsed.expressions).output
     if not isinstance(output, Output):
         raise TypeError("Unknown health check format")
     return output


### PR DESCRIPTION
This commit fixes a merge error where a parameter to a call to
check_health() was not included.

This is part of MON-13160.

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>