### PR TITLE
Update components pod consts.py add PodReadyToStartContainers

### DIFF
--- a/k8s/components/pod/consts.py
+++ b/k8s/components/pod/consts.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-STATUSES = ["Ready", "Initialized", "PodScheduled", "ContainersReady"]
+STATUSES = ["Ready", "Initialized", "PodScheduled", "ContainersReady", "PodReadyToStartContainers"]
 
 
 class ContainerState(Enum):


### PR DESCRIPTION
"PodReadyToStartContainers" missing from STATUSES which leads to pods being in a degraded state within the check. Check stays in warning.' Adding "PodReadyToStartContainers" to STATUSES resolves the issue.

"PodReadyToStartContainers" is a beta feature yet enabled by default:  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions

This feature has been around since Kubernetes 1.29 by the looks of it.