### PR TITLE
Align RPM venv install and runtime interpreter path

### DIFF
--- a/check_k8s.py
+++ b/check_k8s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/opt/plugins/check_k8s/bin/python -I
 
 from k8s.__main__ import main
 

--- a/op5build/check_k8s.spec
+++ b/op5build/check_k8s.spec
@@ -4,8 +4,6 @@
 # Disable automatic dependency detection for venv paths
 %global __requires_exclude ^/opt/plugins/check_k8s/.*$
 
-# Define Python interpreter for byte-code compilation
-%global __python3 %{app_install_path}/bin/python -I
 
 Summary: Kubernetes plugin for Nagios
 Name: monitor-plugin-check_k8s
@@ -48,10 +46,11 @@ Nagios plugin for monitoring Kubernetes Clusters, built using the Python standar
 cd %{app_install_path}
 # Create a new venv
 python3.12 -m venv .
+source bin/activate
 # First install the pip version that was used in the build
-bin/pip install --upgrade -f wheels --no-index --no-deps pip
+pip install --upgrade -f wheels --no-index --no-deps pip
 # Then install all the remaining packages
-bin/pip install --upgrade --no-index wheels/*.whl
+pip install --upgrade --no-index wheels/*.whl
 # Remove the wheels directory, no longer needed
 %{__rm} -rf wheels
 


### PR DESCRIPTION
Ensure build-time pip execution and runtime launcher both use the isolated packaged environment.

Part of MON-13790.